### PR TITLE
Adding termination protection

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "serverless-apigw-binary": "^0.4.4",
     "serverless-iam-roles-per-function": "^2.0.1",
     "serverless-pseudo-parameters": "^2.4.0",
-    "serverless-scriptable-plugin": "^1.0.1"
+    "serverless-scriptable-plugin": "^1.0.1",
+    "serverless-stack-termination-protection": "^1.0.0"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,6 +9,7 @@ plugins:
   - serverless-pseudo-parameters
   - noiiice-plugin
   - build-apps
+    - serverless-stack-termination-protection
 
 provider:
   name: aws
@@ -68,6 +69,9 @@ custom:
     createRoute53Record: true
   postActionsArn: arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${self:provider.stage}-postActions
   commentActionsArn: arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${self:provider.stage}-commentAction
+  serverlessTerminationProtection:
+    stages:
+      - prod
 
 # This is for lambda function server
 layers:

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,7 +9,7 @@ plugins:
   - serverless-pseudo-parameters
   - noiiice-plugin
   - build-apps
-    - serverless-stack-termination-protection
+  - serverless-stack-termination-protection
 
 provider:
   name: aws


### PR DESCRIPTION
It's a good practice to enable termination protection for the CloudFormation stack to avoid accidentally deleting the application. At a minimum, enable termination protection on the prod stage.

This is a great project, btw. I've been waiting to see a completely Serverless blog.